### PR TITLE
Garden runtime support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ well as features available.
 #### Via Go
 
 ```bash
-$ go get github.com/jessfraz/amicontained
+$ go get github.com/genuinetools/amicontained
 ```
 
 ## Usage

--- a/container/container.go
+++ b/container/container.go
@@ -15,20 +15,14 @@ import (
 )
 
 const (
-	// RuntimeDocker is the docker runtime.
-	RuntimeDocker = "docker"
-	// RuntimeRkt is the rkt runtime.
-	RuntimeRkt = "rkt"
-	// RuntimeNspawn is the systemd-nspawn runtime.
-	RuntimeNspawn = "systemd-nspawn"
-	// RuntimeLXC is the lxc runtime.
-	RuntimeLXC = "lxc"
-	// RuntimeLXCLibvirt is the lxc-libvirt runtime.
+	RuntimeDocker     = "docker"
+	RuntimeRkt        = "rkt"
+	RuntimeNspawn     = "systemd-nspawn"
+	RuntimeLXC        = "lxc"
 	RuntimeLXCLibvirt = "lxc-libvirt"
-	// RuntimeOpenVZ is the openvz runtime.
-	RuntimeOpenVZ = "openvz"
-	// RuntimeKubernetes is the kube runtime.
+	RuntimeOpenVZ     = "openvz"
 	RuntimeKubernetes = "kube"
+	RuntimeGarden     = "garden"
 
 	uint32Max = 4294967295
 )
@@ -37,7 +31,7 @@ var (
 	// ErrContainerRuntimeNotFound describes when a container runtime could not be found.
 	ErrContainerRuntimeNotFound = errors.New("container runtime could not be found")
 
-	runtimes = []string{RuntimeDocker, RuntimeRkt, RuntimeNspawn, RuntimeLXC, RuntimeLXCLibvirt, RuntimeOpenVZ, RuntimeKubernetes}
+	runtimes = []string{RuntimeDocker, RuntimeRkt, RuntimeNspawn, RuntimeLXC, RuntimeLXCLibvirt, RuntimeOpenVZ, RuntimeKubernetes, RuntimeGarden}
 )
 
 // DetectRuntime returns the container runtime the process is running in.

--- a/main.go
+++ b/main.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/jessfraz/amicontained/container"
-	"github.com/jessfraz/amicontained/version"
+	"github.com/genuinetools/amicontained/container"
+	"github.com/genuinetools/amicontained/version"
 	"github.com/sirupsen/logrus"
 )
 


### PR DESCRIPTION
There are two parts to this PR, one simply adding [Garden](https://github.com/cloudfoundry/garden-runc-release) (the container piece behind Cloud Foundry) as a runtime. The existing `/proc/self/cgroup` strategy works for Garden out of the box:

**Before**

```
~ # ./amicontained
Container Runtime: not-found
Has Namespaces:
	pid: true
	user: true
User Namespace Mappings:
	Container -> 0	Host -> 4294967294	Range -> 1
	Container -> 1	Host -> 1	Range -> 4294967293
AppArmor Profile: garden-default (enforce)
Capabilities:
	BOUNDING -> chown dac_override fowner fsetid kill setgid setuid setpcap net_bind_service net_raw sys_chroot mknod audit_write setfcap
Chroot (not pivot_root): false
Seccomp: filtering
```

**After**

```
~ # ./amicontained
Container Runtime: garden
Has Namespaces:
	pid: true
	user: true
User Namespace Mappings:
	Container -> 0	Host -> 4294967294	Range -> 1
	Container -> 1	Host -> 1	Range -> 4294967293
AppArmor Profile: garden-default (enforce)
Capabilities:
	BOUNDING -> chown dac_override fowner fsetid kill setgid setuid setpcap net_bind_service net_raw sys_chroot mknod audit_write setfcap
Chroot (not pivot_root): false
Seccomp: filtering
```

The second part of the PR seemed sensible, but I'm not sure on the intent on this repo. I updated some of the paths (still a few release URLs on the README point to the old repo) in the README and in the Go import paths to point to this repo since it seemed like you intended it to become the canonical location.