### PR TITLE
Adds podman support

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -31,6 +31,8 @@ const (
 	RuntimeKubernetes = "kube"
 	// RuntimeGarden is the string for the garden runtime.
 	RuntimeGarden = "garden"
+	// RuntimePodman is the string for the podman runtime.
+	RuntimePodman = "podman"
 
 	uint32Max = 4294967295
 )
@@ -39,7 +41,7 @@ var (
 	// ErrContainerRuntimeNotFound describes when a container runtime could not be found.
 	ErrContainerRuntimeNotFound = errors.New("container runtime could not be found")
 
-	runtimes = []string{RuntimeDocker, RuntimeRkt, RuntimeNspawn, RuntimeLXC, RuntimeLXCLibvirt, RuntimeOpenVZ, RuntimeKubernetes, RuntimeGarden}
+	runtimes = []string{RuntimeDocker, RuntimeRkt, RuntimeNspawn, RuntimeLXC, RuntimeLXCLibvirt, RuntimeOpenVZ, RuntimeKubernetes, RuntimeGarden, RuntimePodman}
 )
 
 // DetectRuntime returns the container runtime the process is running in.


### PR DESCRIPTION
```
$ sudo /usr/bin/podman run --rm -it ipmb/amicontained amicontained
Container Runtime: podman
Has Namespaces:
	pid: true
	user: false
AppArmor Profile: unconfined
Capabilities:
	BOUNDING -> chown dac_override fowner fsetid kill setgid setuid setpcap net_bind_service net_raw sys_chroot mknod audit_write setfcap
	AMBIENT -> chown dac_override fowner fsetid kill setgid setuid setpcap net_bind_service net_raw sys_chroot mknod audit_write setfcap
Chroot (not pivot_root): false
Seccomp: filtering
```

Not sure why, but the `--uidmap` option causes podman to hang against the `scratch` image. Here's what it looks like on Alpine:

```
$ sudo /usr/bin/podman run --rm -it --uidmap=0:886432:65536 -v `pwd`/amicontained:/usr/bin/amicontained alpine amicontained
Container Runtime: podman
Has Namespaces:
	pid: true
	user: true
User Namespace Mappings:
	Container -> 0	Host -> 886432	Range -> 65536
AppArmor Profile: unconfined
Capabilities:
	BOUNDING -> chown dac_override fowner fsetid kill setgid setuid setpcap net_bind_service net_raw sys_chroot mknod audit_write setfcap
	AMBIENT -> chown dac_override fowner fsetid kill setgid setuid setpcap net_bind_service net_raw sys_chroot mknod audit_write setfcap
Chroot (not pivot_root): false
Seccomp: filtering
```