### PR TITLE
Make docker.sock hunting optional

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,8 @@ import (
 )
 
 var (
-	debug bool
+	debug            bool
+	docker_sock_hunt bool
 )
 
 func main() {
@@ -36,6 +37,7 @@ func main() {
 	// Setup the global flags.
 	p.FlagSet = flag.NewFlagSet("ship", flag.ExitOnError)
 	p.FlagSet.BoolVar(&debug, "d", false, "enable debug logging")
+	p.FlagSet.BoolVar(&docker_sock_hunt, "s", false, "enable docker sock hunting")
 
 	// Set the before function.
 	p.Before = func(ctx context.Context) error {
@@ -99,9 +101,11 @@ func main() {
 
 		seccompIter()
 
-		// Docker.sock
-		fmt.Println("Looking for Docker.sock")
-		getValidSockets("/")
+		if docker_sock_hunt {
+			// Docker.sock
+			fmt.Println("Looking for Docker.sock")
+			getValidSockets("/")
+		}
 
 		return nil
 	}


### PR DESCRIPTION
The `docker.sock` hunting often hangs or takes a very long time depending on the runtime and what sockets are in the container/host.

This PR makes it optional, default off (this is a behaviour change).
I tried to make default `true` but then I could find how to have the CLI flag turn it off, I don't understand `pkg/cli` properly, or perhaps its not possible.

After this PR:
* Run `amicontained -s` to look for docker.sock (the old behaviour).
* Run `amicontained` to skip looking for docker.sock